### PR TITLE
Revert "improved docker workflow, added start, build, and push scripts"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,29 +14,29 @@ RUN apt-get -qq update && \
     apt-get -qq install -y \
 	apt-utils \
 	libeigen3-dev \
-    python-catkin-tools  \
-    less \
-    ssh \
+        python-catkin-tools  \
+        less \
+        ssh \
 	vim \
 	terminator \
-    git-core \
-    bash-completion \
-    wget \
-    qtbase5-dev \ 
-    libqt5svg5-dev \ 
-    libzmq3-dev \ 
-    libdw-dev
+        git-core \
+        bash-completion \
+        wget
 
 # HACK, replacing shell with bash for later docker build commands
 RUN mv /bin/sh /bin/sh-old && \
     ln -s /bin/bash /bin/sh
 
-# get source
-COPY . .
+# download lawn_tractor_sim source 
+RUN git clone -b 'develop' --single-branch --depth 1 https://github.com/ros-agriculture/lawn_tractor.git 
+RUN git clone https://github.com/bsb808/geonav_transform.git
 
 RUN echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
 RUN echo "source $CATKIN_WS/devel/setup.bash" >> ~/.bashrc
 
+# Why do I have to do this?
+#RUN apt-get -qq update && apt-get -qq upgrade && \
+    # sudo apt-get -qq install -y ros-kinetic-teb-local-planner && \
 RUN rosdep update && \
     rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     apt-get -qq upgrade && \
@@ -46,13 +46,7 @@ RUN rosdep update && \
 WORKDIR $CATKIN_WS
 ENV TERM xterm
 ENV PYTHONIOENCODING UTF-8 
-RUN git clone https://github.com/BehaviorTree/Groot.git && \
-   cd Groot && \
-   git submodule update --init --recursive && \
-   mkdir build; cd build && \
-   cmake .. && \
-   make && \
-   cd ..
+
 RUN source /ros_entrypoint.sh && \
     catkin build --no-status
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,1 +1,0 @@
-docker build . -t rosagriculture/lawn_tractor:latest

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,2 +1,0 @@
-# You must be logged in to a privlidged account for this
-docker push rosagriculture/lawn_tractor 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,6 +1,6 @@
 # This is not the safest way however, as you then compromise the access control to X server on your host
 xhost +local:root # for the lazy and reckless
-docker run -it --env="DISPLAY" --network="host" --privileged -v /dev:/dev --env="QT_X11_NO_MITSHM=1" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" rosagriculture/lawn_tractor 
+docker run -it --env="DISPLAY" --network="host" --privileged -v /dev:/dev --env="QT_X11_NO_MITSHM=1" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" rosagriculture/tractor_sim 
 export containerId=$(docker ps -l -q)
 # Close security hole:
 xhost -local:root


### PR DESCRIPTION
Reverts ros-agriculture/lawn_tractor#18

Docker build fails at:
lawn_tractor/docker$ ./build.sh
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /home/matt/ros/tractorsim_ws/lawn_tractor_pr/lawn_tractor/docker/Dockerfile: no such file or directory
Fix: Move build.sh to root dir.

The container fails to build with the message:
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
lawn_tractor_navigation: Cannot locate rosdep definition for [geonav_transform]
The command '/bin/sh -c rosdep update && rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && apt-get -qq upgrade && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 1