### PR TITLE
Feature/bt cancel goal

### DIFF
--- a/lawn_tractor_navigation/config/behavior_tree/movebaseflex_tree.xml
+++ b/lawn_tractor_navigation/config/behavior_tree/movebaseflex_tree.xml
@@ -1,16 +1,15 @@
  <root >
      <BehaviorTree>
         <Repeat num_cycles="10">
+	    <ForceSuccess>
             <Sequence>
                 <Timeout msec="10000">
                     <WaitForGoal goal="{goal_pose}" />
                 </Timeout>
                 <GetPath server_name="move_base_flex/get_path" goalpose="{goal_pose}" result="{pathResultPtr}"/>
-                <Fallback>
-                    <ExePath server_name="move_base_flex/exe_path" pathPtr="{pathResultPtr}" />
-                    <Recovery server_name="move_base_flex/recovery" />
-                </Fallback>
+                <ExePath server_name="move_base_flex/exe_path" pathPtr="{pathResultPtr}" />
             </Sequence>
+            </ForceSuccess>
         </Repeat>
      </BehaviorTree>
  </root>


### PR DESCRIPTION
Addresses #22 

- Get rid of the Recovery Behavior in the BT (it wasn't working anyways, See #15 )

- Force Success so that when the `exe_path` action is cancelled, the BT still repeats and goes to `wait_for_goal`

While the robot is moving to the goal, you can cancel by invoking:
`rostopic pub -1 /move_base_flex/exe_path/cancel actionlib_msgs/GoalID -- {}`

Future work should include making an RVIZ button to invoke this cancellation (see #25 )